### PR TITLE
Support UTF8 in config file (Closes #36)

### DIFF
--- a/bin/lsregistrationdaemon.pl
+++ b/bin/lsregistrationdaemon.pl
@@ -174,7 +174,7 @@ my $flap_count = 0;
 my $current_ls_instance = "";
 while(1){
     eval{
-        %conf = Config::General->new( $CONFIG_FILE )->getall();
+        %conf = Config::General->new( -ConfigFile => $CONFIG_FILE, -UTF8 => 1 )->getall();
     };
     if($@){
          $logger->error( "Error reading config file $CONFIG_FILE. Proceeding with defaults: Caused by: $@");

--- a/etc/lsregistrationdaemon-logger.conf
+++ b/etc/lsregistrationdaemon-logger.conf
@@ -14,6 +14,7 @@ log4perl.appender.A1.max=7
 log4perl.appender.A1.DatePattern=yyyy-MM-dd
 log4perl.appender.A1.permissions=sub{ 0644; }
 log4perl.appender.A1.mode=append
+log4perl.appender.A1.binmode=:encoding(UTF-8)
 
 
 log4perl.appender.A1.layout=Log::Log4perl::Layout::PatternLayout

--- a/lib/perfSONAR_PS/LSRegistrationDaemon/Base.pm
+++ b/lib/perfSONAR_PS/LSRegistrationDaemon/Base.pm
@@ -492,6 +492,7 @@ sub build_checksum {
     
     $self->{LOGGER}->debug("Checksum prior to md5 is " . $checksum);
 
+    utf8::encode($checksum); # convert to binary for md5 to work
     $checksum = md5_base64($checksum);
 
     $self->{LOGGER}->debug("Checksum is " . $checksum);
@@ -509,6 +510,7 @@ sub build_duplicate_checksum {
     
     $self->{LOGGER}->debug("Duplicate checksum prior to md5 is " . $checksum);
 
+    utf8::encode($checksum); # convert to binary for md5 to work
     $checksum = md5_base64($checksum);
 
     $self->{LOGGER}->debug("Duplicate checksum is " . $checksum);


### PR DESCRIPTION
Enables UTF8 for reading the config and writing to the log. Also fixes MD5 with wide characters.